### PR TITLE
Upgrade kolibri-js to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,11 @@
       "devDependencies": {
         "@dicebear/avatars": "4.2.5",
         "@dicebear/avatars-bottts-sprites": "4.2.5",
-        "@hover-labs/kolibri-js": "^1.15.2",
+        "@hover-labs/kolibri-js": "^2.0.0",
         "@sweetalert2/theme-bulma": "^4.0.1",
         "@taquito/local-forging": "^9.1.0",
         "@taquito/michelson-encoder": "^9.1.0",
         "@taquito/taquito": "^9.1.0",
-        "@thanos-wallet/dapp": "^2.2.2",
         "@vue/cli-plugin-babel": "~4.5.0",
         "@vue/cli-plugin-eslint": "~4.5.0",
         "@vue/cli-service": "~4.5.0",
@@ -1414,18 +1413,114 @@
       }
     },
     "node_modules/@hover-labs/kolibri-js": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-1.15.2.tgz",
-      "integrity": "sha512-aAZPZFzQWMM0TEJIQHDSs19HslCmH29HQE6TKk7/qJ6gq//cC5l76mjYko/LKoPWOHWBsEpLeGl8HKZM4J08pQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-2.0.0.tgz",
+      "integrity": "sha512-C7z8e58YzktYpfTzuxAD1xEN8uBMKp2s9eDfeR1/h5/ywVYXOqBvmLfKpUBJP9224KWmT62/EXxLAyG1gftDaQ==",
       "dev": true,
       "dependencies": {
-        "@taquito/signer": "10.1.1",
-        "@taquito/taquito": "^9.1.0",
-        "@thanos-wallet/dapp": "^2.2.1",
+        "@taquito/signer": "^10.2.1",
+        "@taquito/taquito": "^10.2.0",
+        "@temple-wallet/dapp": "^5.0.2",
         "axios": "^0.21.0",
         "bignumber.js": "^9.0.1",
         "blakejs": "^1.1.1",
         "bs58check": "^2.1.2"
+      }
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/@taquito/http-utils": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-10.2.1.tgz",
+      "integrity": "sha512-RZmGxJFllTHC5LuxrPcVQoH/MpDvQehLjE1czSmL2Dz1VZlzI4Q6Ie+pG5nHQODRPqE8ABi/2aHAGGYMQWqKZg==",
+      "dev": true,
+      "dependencies": {
+        "xhr2-cookies": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/@taquito/michel-codec": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-10.2.1.tgz",
+      "integrity": "sha512-VSHELyuiwso1qCpAEZkH7JdDlZdHxTjyvZcBsfnfpbdpCrAUpCB48P4NZOnvZ58SYt9VS1bNAa5GRvQyOnNvMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/@taquito/michelson-encoder": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-10.2.1.tgz",
+      "integrity": "sha512-HYCtDGCWtyCgOQjmxYLYw5ftejG0FUfAW1FzZWIW6w2ars1TInSbLNeVRZs+EmbD3L8wOaxaOlgdsMoDnGqM/g==",
+      "dev": true,
+      "dependencies": {
+        "@taquito/rpc": "^10.2.1",
+        "@taquito/utils": "^10.2.1",
+        "bignumber.js": "^9.0.1",
+        "fast-json-stable-stringify": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/@taquito/rpc": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-10.2.1.tgz",
+      "integrity": "sha512-Vg80sGLICkEKGls+7YEd0uFpsp8dwx2kNeGgCbpNROIs0S6Slsd0UfDlaZGlllWeUAKr5r6baexYrTKFuWs/UA==",
+      "dev": true,
+      "dependencies": {
+        "@taquito/http-utils": "^10.2.1",
+        "bignumber.js": "^9.0.1",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/@taquito/taquito": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-10.2.1.tgz",
+      "integrity": "sha512-ay61aKhFQPnYGu5d9jqEvaZE0EzE6tO9MD+5vOu6/NFVThBd7ysOQS1PB0VprL9SupM1NVDFnEJ8GtE8SYgk8g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@taquito/http-utils": "^10.2.1",
+        "@taquito/michel-codec": "^10.2.1",
+        "@taquito/michelson-encoder": "^10.2.1",
+        "@taquito/rpc": "^10.2.1",
+        "@taquito/utils": "^10.2.1",
+        "bignumber.js": "^9.0.1",
+        "rx-sandbox": "^1.0.4",
+        "rxjs": "^6.6.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/@taquito/utils": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-10.2.1.tgz",
+      "integrity": "sha512-oW/D9irojwjorIV/0yO32Gyr+zSnITkVkOwVmnxge6DYHWC7aqPbdwiDwc4/GewKXNngBDqDEjEEPhkp0ZnvJw==",
+      "dev": true,
+      "dependencies": {
+        "blakejs": "^1.1.0",
+        "bs58check": "^2.1.2",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/@temple-wallet/dapp": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@temple-wallet/dapp/-/dapp-5.0.2.tgz",
+      "integrity": "sha512-IIeHTowHXOp7/JnttfzMyCJjFWwhqOauDN7S2vU0GzHkpT5gH6FBXqB3kvZUyPfoxY0PXuXg+HKh++qABx+g9A==",
+      "dev": true,
+      "dependencies": {
+        "nanoid": "^3.1.25"
+      },
+      "peerDependencies": {
+        "@taquito/taquito": "^10.0.0"
       }
     },
     "node_modules/@hover-labs/kolibri-js/node_modules/blakejs": {
@@ -1433,6 +1528,30 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==",
       "dev": true
+    },
+    "node_modules/@hover-labs/kolibri-js/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
@@ -1749,13 +1868,13 @@
       }
     },
     "node_modules/@taquito/signer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-10.1.1.tgz",
-      "integrity": "sha512-C1YRVqKYXAj6zxYFaYX3/Ik9uVJd5/2lNst0az7Pz/9oIwGpnuub2tfrCVMkyfe+eOu6hcVrnCkaK2HKZzpaSA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-10.2.1.tgz",
+      "integrity": "sha512-pogjVL7l+J27ABAzfgkDqTu2YQHPIj1WNcU9xBeQMf1CSUXXeTz/C4wvAQHi4xPKL3PDz4Hh16TP8+c+r6ZMUQ==",
       "dev": true,
       "dependencies": {
-        "@taquito/taquito": "^10.1.1",
-        "@taquito/utils": "^10.1.1",
+        "@taquito/taquito": "^10.2.1",
+        "@taquito/utils": "^10.2.1",
         "bignumber.js": "^9.0.1",
         "bip39": "^3.0.4",
         "elliptic": "^6.5.4",
@@ -1768,9 +1887,9 @@
       }
     },
     "node_modules/@taquito/signer/node_modules/@taquito/http-utils": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-10.2.0.tgz",
-      "integrity": "sha512-HUrR2D8JeSUZMQLavGRj2tpTk8a0SmI2HbzhP/akFXb62GVMH6QQEDhz8xqhSyCLHqHKW6obkGH5TlDIbvJEsA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-10.2.1.tgz",
+      "integrity": "sha512-RZmGxJFllTHC5LuxrPcVQoH/MpDvQehLjE1czSmL2Dz1VZlzI4Q6Ie+pG5nHQODRPqE8ABi/2aHAGGYMQWqKZg==",
       "dev": true,
       "dependencies": {
         "xhr2-cookies": "^1.1.0"
@@ -1780,22 +1899,22 @@
       }
     },
     "node_modules/@taquito/signer/node_modules/@taquito/michel-codec": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-10.2.0.tgz",
-      "integrity": "sha512-dndIFumnebwhMCdhGv89dVJPIsTbB885LYLuPYyp7saYqlVe8n+NKlfSkHn+G/7waj8Xt5uzHsxYHPK9R9CvSQ==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-10.2.1.tgz",
+      "integrity": "sha512-VSHELyuiwso1qCpAEZkH7JdDlZdHxTjyvZcBsfnfpbdpCrAUpCB48P4NZOnvZ58SYt9VS1bNAa5GRvQyOnNvMQ==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@taquito/signer/node_modules/@taquito/michelson-encoder": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-10.2.0.tgz",
-      "integrity": "sha512-jLGG8sdpDvhLXbwhx1OP4LoRAYp1RBIkHjppm4q5duMGxfnIK+HPO9l0X5VPouNRXK0fCquceEO1r99EgKJv1Q==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-10.2.1.tgz",
+      "integrity": "sha512-HYCtDGCWtyCgOQjmxYLYw5ftejG0FUfAW1FzZWIW6w2ars1TInSbLNeVRZs+EmbD3L8wOaxaOlgdsMoDnGqM/g==",
       "dev": true,
       "dependencies": {
-        "@taquito/rpc": "^10.2.0",
-        "@taquito/utils": "^10.2.0",
+        "@taquito/rpc": "^10.2.1",
+        "@taquito/utils": "^10.2.1",
         "bignumber.js": "^9.0.1",
         "fast-json-stable-stringify": "^2.1.0"
       },
@@ -1804,12 +1923,12 @@
       }
     },
     "node_modules/@taquito/signer/node_modules/@taquito/rpc": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-10.2.0.tgz",
-      "integrity": "sha512-ryUCUHlpxo365XdxnLI0PQdzeg0Idnkxg6CZwNvppPRVEszTBKtfOOtBXmSFOhiEZcH7z9qTCuK1/vpInst0JA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-10.2.1.tgz",
+      "integrity": "sha512-Vg80sGLICkEKGls+7YEd0uFpsp8dwx2kNeGgCbpNROIs0S6Slsd0UfDlaZGlllWeUAKr5r6baexYrTKFuWs/UA==",
       "dev": true,
       "dependencies": {
-        "@taquito/http-utils": "^10.2.0",
+        "@taquito/http-utils": "^10.2.1",
         "bignumber.js": "^9.0.1",
         "lodash": "^4.17.21"
       },
@@ -1818,17 +1937,17 @@
       }
     },
     "node_modules/@taquito/signer/node_modules/@taquito/taquito": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-10.2.0.tgz",
-      "integrity": "sha512-IO8A6OCtNpQ2D7birQ8QUcVZYUdQSmGeP/Y4rdEbFhl287h2NqLUi33pjgsYKgBuDgVG0SA18ouA8t9Aj16Jng==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-10.2.1.tgz",
+      "integrity": "sha512-ay61aKhFQPnYGu5d9jqEvaZE0EzE6tO9MD+5vOu6/NFVThBd7ysOQS1PB0VprL9SupM1NVDFnEJ8GtE8SYgk8g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@taquito/http-utils": "^10.2.0",
-        "@taquito/michel-codec": "^10.2.0",
-        "@taquito/michelson-encoder": "^10.2.0",
-        "@taquito/rpc": "^10.2.0",
-        "@taquito/utils": "^10.2.0",
+        "@taquito/http-utils": "^10.2.1",
+        "@taquito/michel-codec": "^10.2.1",
+        "@taquito/michelson-encoder": "^10.2.1",
+        "@taquito/rpc": "^10.2.1",
+        "@taquito/utils": "^10.2.1",
         "bignumber.js": "^9.0.1",
         "rx-sandbox": "^1.0.4",
         "rxjs": "^6.6.3"
@@ -1838,9 +1957,9 @@
       }
     },
     "node_modules/@taquito/signer/node_modules/@taquito/utils": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-10.2.0.tgz",
-      "integrity": "sha512-UF8XZG/F9LItXENFuw43w/kaQGjMpAjMnTNBAGFo5Qzq95iZgmhfnp8B0gAAEas53Yu0DpFyPUj7LTOlIBOG7g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-10.2.1.tgz",
+      "integrity": "sha512-oW/D9irojwjorIV/0yO32Gyr+zSnITkVkOwVmnxge6DYHWC7aqPbdwiDwc4/GewKXNngBDqDEjEEPhkp0ZnvJw==",
       "dev": true,
       "dependencies": {
         "blakejs": "^1.1.0",
@@ -1920,18 +2039,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@thanos-wallet/dapp": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@thanos-wallet/dapp/-/dapp-2.2.2.tgz",
-      "integrity": "sha512-FI22fVaU0AMeGrGAYHvIy5iPA3ttZaKPRbwOYK4NIvUCSc8Ah3FIhs196rY1BHtz9XgrhzBknbZ7PzGakV88qA==",
-      "dev": true,
-      "dependencies": {
-        "nanoid": "^3.1.10"
-      },
-      "peerDependencies": {
-        "@taquito/taquito": "^7.0.0 || ^7.0.0-beta || ^8.0.0-beta"
       }
     },
     "node_modules/@types/anymatch": {
@@ -10352,9 +10459,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -18004,25 +18111,109 @@
       }
     },
     "@hover-labs/kolibri-js": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-1.15.2.tgz",
-      "integrity": "sha512-aAZPZFzQWMM0TEJIQHDSs19HslCmH29HQE6TKk7/qJ6gq//cC5l76mjYko/LKoPWOHWBsEpLeGl8HKZM4J08pQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-2.0.0.tgz",
+      "integrity": "sha512-C7z8e58YzktYpfTzuxAD1xEN8uBMKp2s9eDfeR1/h5/ywVYXOqBvmLfKpUBJP9224KWmT62/EXxLAyG1gftDaQ==",
       "dev": true,
       "requires": {
-        "@taquito/signer": "10.1.1",
-        "@taquito/taquito": "^9.1.0",
-        "@thanos-wallet/dapp": "^2.2.1",
+        "@taquito/signer": "^10.2.1",
+        "@taquito/taquito": "^10.2.0",
+        "@temple-wallet/dapp": "^5.0.2",
         "axios": "^0.21.0",
         "bignumber.js": "^9.0.1",
         "blakejs": "^1.1.1",
         "bs58check": "^2.1.2"
       },
       "dependencies": {
+        "@taquito/http-utils": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-10.2.1.tgz",
+          "integrity": "sha512-RZmGxJFllTHC5LuxrPcVQoH/MpDvQehLjE1czSmL2Dz1VZlzI4Q6Ie+pG5nHQODRPqE8ABi/2aHAGGYMQWqKZg==",
+          "dev": true,
+          "requires": {
+            "xhr2-cookies": "^1.1.0"
+          }
+        },
+        "@taquito/michel-codec": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-10.2.1.tgz",
+          "integrity": "sha512-VSHELyuiwso1qCpAEZkH7JdDlZdHxTjyvZcBsfnfpbdpCrAUpCB48P4NZOnvZ58SYt9VS1bNAa5GRvQyOnNvMQ==",
+          "dev": true
+        },
+        "@taquito/michelson-encoder": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-10.2.1.tgz",
+          "integrity": "sha512-HYCtDGCWtyCgOQjmxYLYw5ftejG0FUfAW1FzZWIW6w2ars1TInSbLNeVRZs+EmbD3L8wOaxaOlgdsMoDnGqM/g==",
+          "dev": true,
+          "requires": {
+            "@taquito/rpc": "^10.2.1",
+            "@taquito/utils": "^10.2.1",
+            "bignumber.js": "^9.0.1",
+            "fast-json-stable-stringify": "^2.1.0"
+          }
+        },
+        "@taquito/rpc": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-10.2.1.tgz",
+          "integrity": "sha512-Vg80sGLICkEKGls+7YEd0uFpsp8dwx2kNeGgCbpNROIs0S6Slsd0UfDlaZGlllWeUAKr5r6baexYrTKFuWs/UA==",
+          "dev": true,
+          "requires": {
+            "@taquito/http-utils": "^10.2.1",
+            "bignumber.js": "^9.0.1",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@taquito/taquito": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-10.2.1.tgz",
+          "integrity": "sha512-ay61aKhFQPnYGu5d9jqEvaZE0EzE6tO9MD+5vOu6/NFVThBd7ysOQS1PB0VprL9SupM1NVDFnEJ8GtE8SYgk8g==",
+          "dev": true,
+          "requires": {
+            "@taquito/http-utils": "^10.2.1",
+            "@taquito/michel-codec": "^10.2.1",
+            "@taquito/michelson-encoder": "^10.2.1",
+            "@taquito/rpc": "^10.2.1",
+            "@taquito/utils": "^10.2.1",
+            "bignumber.js": "^9.0.1",
+            "rx-sandbox": "^1.0.4",
+            "rxjs": "^6.6.3"
+          }
+        },
+        "@taquito/utils": {
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-10.2.1.tgz",
+          "integrity": "sha512-oW/D9irojwjorIV/0yO32Gyr+zSnITkVkOwVmnxge6DYHWC7aqPbdwiDwc4/GewKXNngBDqDEjEEPhkp0ZnvJw==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "bs58check": "^2.1.2",
+            "buffer": "^6.0.3"
+          }
+        },
+        "@temple-wallet/dapp": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@temple-wallet/dapp/-/dapp-5.0.2.tgz",
+          "integrity": "sha512-IIeHTowHXOp7/JnttfzMyCJjFWwhqOauDN7S2vU0GzHkpT5gH6FBXqB3kvZUyPfoxY0PXuXg+HKh++qABx+g9A==",
+          "dev": true,
+          "requires": {
+            "nanoid": "^3.1.25"
+          }
+        },
         "blakejs": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
           "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==",
           "dev": true
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
         }
       }
     },
@@ -18270,13 +18461,13 @@
       }
     },
     "@taquito/signer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-10.1.1.tgz",
-      "integrity": "sha512-C1YRVqKYXAj6zxYFaYX3/Ik9uVJd5/2lNst0az7Pz/9oIwGpnuub2tfrCVMkyfe+eOu6hcVrnCkaK2HKZzpaSA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-10.2.1.tgz",
+      "integrity": "sha512-pogjVL7l+J27ABAzfgkDqTu2YQHPIj1WNcU9xBeQMf1CSUXXeTz/C4wvAQHi4xPKL3PDz4Hh16TP8+c+r6ZMUQ==",
       "dev": true,
       "requires": {
-        "@taquito/taquito": "^10.1.1",
-        "@taquito/utils": "^10.1.1",
+        "@taquito/taquito": "^10.2.1",
+        "@taquito/utils": "^10.2.1",
         "bignumber.js": "^9.0.1",
         "bip39": "^3.0.4",
         "elliptic": "^6.5.4",
@@ -18286,63 +18477,63 @@
       },
       "dependencies": {
         "@taquito/http-utils": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-10.2.0.tgz",
-          "integrity": "sha512-HUrR2D8JeSUZMQLavGRj2tpTk8a0SmI2HbzhP/akFXb62GVMH6QQEDhz8xqhSyCLHqHKW6obkGH5TlDIbvJEsA==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-10.2.1.tgz",
+          "integrity": "sha512-RZmGxJFllTHC5LuxrPcVQoH/MpDvQehLjE1czSmL2Dz1VZlzI4Q6Ie+pG5nHQODRPqE8ABi/2aHAGGYMQWqKZg==",
           "dev": true,
           "requires": {
             "xhr2-cookies": "^1.1.0"
           }
         },
         "@taquito/michel-codec": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-10.2.0.tgz",
-          "integrity": "sha512-dndIFumnebwhMCdhGv89dVJPIsTbB885LYLuPYyp7saYqlVe8n+NKlfSkHn+G/7waj8Xt5uzHsxYHPK9R9CvSQ==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-10.2.1.tgz",
+          "integrity": "sha512-VSHELyuiwso1qCpAEZkH7JdDlZdHxTjyvZcBsfnfpbdpCrAUpCB48P4NZOnvZ58SYt9VS1bNAa5GRvQyOnNvMQ==",
           "dev": true
         },
         "@taquito/michelson-encoder": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-10.2.0.tgz",
-          "integrity": "sha512-jLGG8sdpDvhLXbwhx1OP4LoRAYp1RBIkHjppm4q5duMGxfnIK+HPO9l0X5VPouNRXK0fCquceEO1r99EgKJv1Q==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-10.2.1.tgz",
+          "integrity": "sha512-HYCtDGCWtyCgOQjmxYLYw5ftejG0FUfAW1FzZWIW6w2ars1TInSbLNeVRZs+EmbD3L8wOaxaOlgdsMoDnGqM/g==",
           "dev": true,
           "requires": {
-            "@taquito/rpc": "^10.2.0",
-            "@taquito/utils": "^10.2.0",
+            "@taquito/rpc": "^10.2.1",
+            "@taquito/utils": "^10.2.1",
             "bignumber.js": "^9.0.1",
             "fast-json-stable-stringify": "^2.1.0"
           }
         },
         "@taquito/rpc": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-10.2.0.tgz",
-          "integrity": "sha512-ryUCUHlpxo365XdxnLI0PQdzeg0Idnkxg6CZwNvppPRVEszTBKtfOOtBXmSFOhiEZcH7z9qTCuK1/vpInst0JA==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-10.2.1.tgz",
+          "integrity": "sha512-Vg80sGLICkEKGls+7YEd0uFpsp8dwx2kNeGgCbpNROIs0S6Slsd0UfDlaZGlllWeUAKr5r6baexYrTKFuWs/UA==",
           "dev": true,
           "requires": {
-            "@taquito/http-utils": "^10.2.0",
+            "@taquito/http-utils": "^10.2.1",
             "bignumber.js": "^9.0.1",
             "lodash": "^4.17.21"
           }
         },
         "@taquito/taquito": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-10.2.0.tgz",
-          "integrity": "sha512-IO8A6OCtNpQ2D7birQ8QUcVZYUdQSmGeP/Y4rdEbFhl287h2NqLUi33pjgsYKgBuDgVG0SA18ouA8t9Aj16Jng==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-10.2.1.tgz",
+          "integrity": "sha512-ay61aKhFQPnYGu5d9jqEvaZE0EzE6tO9MD+5vOu6/NFVThBd7ysOQS1PB0VprL9SupM1NVDFnEJ8GtE8SYgk8g==",
           "dev": true,
           "requires": {
-            "@taquito/http-utils": "^10.2.0",
-            "@taquito/michel-codec": "^10.2.0",
-            "@taquito/michelson-encoder": "^10.2.0",
-            "@taquito/rpc": "^10.2.0",
-            "@taquito/utils": "^10.2.0",
+            "@taquito/http-utils": "^10.2.1",
+            "@taquito/michel-codec": "^10.2.1",
+            "@taquito/michelson-encoder": "^10.2.1",
+            "@taquito/rpc": "^10.2.1",
+            "@taquito/utils": "^10.2.1",
             "bignumber.js": "^9.0.1",
             "rx-sandbox": "^1.0.4",
             "rxjs": "^6.6.3"
           }
         },
         "@taquito/utils": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-10.2.0.tgz",
-          "integrity": "sha512-UF8XZG/F9LItXENFuw43w/kaQGjMpAjMnTNBAGFo5Qzq95iZgmhfnp8B0gAAEas53Yu0DpFyPUj7LTOlIBOG7g==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-10.2.1.tgz",
+          "integrity": "sha512-oW/D9irojwjorIV/0yO32Gyr+zSnITkVkOwVmnxge6DYHWC7aqPbdwiDwc4/GewKXNngBDqDEjEEPhkp0ZnvJw==",
           "dev": true,
           "requires": {
             "blakejs": "^1.1.0",
@@ -18399,15 +18590,6 @@
         "blakejs": "^1.1.0",
         "bs58check": "^2.1.2",
         "buffer": "^5.6.0"
-      }
-    },
-    "@thanos-wallet/dapp": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@thanos-wallet/dapp/-/dapp-2.2.2.tgz",
-      "integrity": "sha512-FI22fVaU0AMeGrGAYHvIy5iPA3ttZaKPRbwOYK4NIvUCSc8Ah3FIhs196rY1BHtz9XgrhzBknbZ7PzGakV88qA==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^3.1.10"
       }
     },
     "@types/anymatch": {
@@ -25253,9 +25435,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
       "dev": true
     },
     "nanomatch": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
   "devDependencies": {
     "@dicebear/avatars": "4.2.5",
     "@dicebear/avatars-bottts-sprites": "4.2.5",
-    "@hover-labs/kolibri-js": "^1.15.2",
+    "@hover-labs/kolibri-js": "^2.0.0",
     "@sweetalert2/theme-bulma": "^4.0.1",
     "@taquito/local-forging": "^9.1.0",
     "@taquito/michelson-encoder": "^9.1.0",
     "@taquito/taquito": "^9.1.0",
-    "@thanos-wallet/dapp": "^2.2.2",
     "@vue/cli-plugin-babel": "~4.5.0",
     "@vue/cli-plugin-eslint": "~4.5.0",
     "@vue/cli-service": "~4.5.0",


### PR DESCRIPTION
Notably this moves kolibri-js from using the `thanoswallet/dapp` module to the `templewallet/dapp` module. Remove Also `thanoswallet/dapp` since it isn't used in the front end. 

The only thing I remain unsure about is if this constant needs to change:
https://github.com/Hover-Labs/kolibri-frontend/blob/a8d471708a86cdaf695a7e8348d6538c9450f802/src/components/WalletManager.vue#L77

I can't find documentation on this constant and don't readily see it documented in [Taquito's](https://tezostaquito.io/docs/wallet_api/) or [Temple's](https://www.npmjs.com/package/@temple-wallet/dapp) docs on wallets. 