### PR TITLE
Bump Frontend To Pull in Sandbox Contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@dicebear/avatars": "4.2.5",
         "@dicebear/avatars-bottts-sprites": "4.2.5",
-        "@hover-labs/kolibri-js": "^3.2.5",
+        "@hover-labs/kolibri-js": "^3.2.7",
         "@sweetalert2/theme-bulma": "^4.0.1",
         "@taquito/local-forging": "^10.2.1",
         "@taquito/michelson-encoder": "^10.2.1",
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@hover-labs/kolibri-js": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-3.2.5.tgz",
-      "integrity": "sha512-auZklEjPWI5CbVYUYgdyF3JOxHL7fBT2HKST8FzKG1YqRjX4dgi2tAL9gtlAhYSENj7VSjiosC4Zcq68nFb79g==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-3.2.7.tgz",
+      "integrity": "sha512-izT9NVbA+JBXYGcags/VK2twD0eSBHXprAyjHN4UZrZ5gr+xkuH5JmwALvV1kzTPFQkx/3k/t5i6mv7YaAOXuw==",
       "dev": true,
       "dependencies": {
         "@taquito/signer": "^11.2.0",
@@ -18419,9 +18419,9 @@
       }
     },
     "@hover-labs/kolibri-js": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-3.2.5.tgz",
-      "integrity": "sha512-auZklEjPWI5CbVYUYgdyF3JOxHL7fBT2HKST8FzKG1YqRjX4dgi2tAL9gtlAhYSENj7VSjiosC4Zcq68nFb79g==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@hover-labs/kolibri-js/-/kolibri-js-3.2.7.tgz",
+      "integrity": "sha512-izT9NVbA+JBXYGcags/VK2twD0eSBHXprAyjHN4UZrZ5gr+xkuH5JmwALvV1kzTPFQkx/3k/t5i6mv7YaAOXuw==",
       "dev": true,
       "requires": {
         "@taquito/signer": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@dicebear/avatars": "4.2.5",
     "@dicebear/avatars-bottts-sprites": "4.2.5",
-    "@hover-labs/kolibri-js": "^3.2.5",
+    "@hover-labs/kolibri-js": "^3.2.7",
     "@sweetalert2/theme-bulma": "^4.0.1",
     "@taquito/local-forging": "^10.2.1",
     "@taquito/michelson-encoder": "^10.2.1",


### PR DESCRIPTION
Contracts now have upgrades 1.1, 1.2 and 1.2.1 applied. 