### PR TITLE
fix: make sure all computations are on-chain value collateral ratio b…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,6 +78,7 @@ export default {
 
       this.$store.collateralRate = minterStorage.collateralizationPercentage;
       this.$store.privateLiquidationThreshold = minterStorage.privateOwnerLiquidationThreshold || null;
+      this.$store.collateralOperand =  this.$store.collateralRate.minus(this.$store.privateLiquidationThreshold ?? 0).dividedBy(Math.pow(10, 20))
     },
     async updateAllOvenData(){
       try {

--- a/src/components/Oven.vue
+++ b/src/components/Oven.vue
@@ -182,16 +182,16 @@
             </p>
             <p class="heading">
               Collateral Utilization:
-              <strong v-if="collatoralizedRate(ovenData.balance) < 80"
-                >{{ collatoralizedRate(ovenData.balance) }}%</strong
+              <strong v-if="collatoralizedRate(ovenData) < 80"
+                >{{ collatoralizedRate(ovenData) }}%</strong
               >
               <strong
-                v-else-if="collatoralizedRate(ovenData.balance) < 100"
+                v-else-if="collatoralizedRate(ovenData) < 100"
                 class="has-text-warning"
-                >{{ collatoralizedRate(ovenData.balance) }}%</strong
+                >{{ collatoralizedRate(ovenData) }}%</strong
               >
               <strong v-else class="has-text-danger"
-                >{{ collatoralizedRate(ovenData.balance) }}%</strong
+                >{{ collatoralizedRate(ovenData) }}%</strong
               >
 
               <span v-if="!outstandingTokens(ovenAddress).isZero()">
@@ -211,28 +211,28 @@
 
             <div class="allocation-info is-fullwidth">
               <progress
-                v-if="collatoralizedRate(ovenData.balance) < 80"
+                v-if="collatoralizedRate(ovenData) < 80"
                 class="progress is-primary"
-                :value="collatoralizedRate(ovenData.balance)"
+                :value="collatoralizedRate(ovenData)"
                 max="100"
               >
-                {{ collatoralizedRate(ovenData.balance) }}%
+                {{ collatoralizedRate(ovenData) }}%
               </progress>
               <progress
-                v-else-if="collatoralizedRate(ovenData.balance) < 100"
+                v-else-if="collatoralizedRate(ovenData) < 100"
                 class="progress is-warning"
-                :value="collatoralizedRate(ovenData.balance)"
+                :value="collatoralizedRate(ovenData)"
                 max="100"
               >
-                {{ collatoralizedRate(ovenData.balance) }}%
+                {{ collatoralizedRate(ovenData) }}%
               </progress>
               <progress
                 v-else
                 class="progress is-danger"
-                :value="collatoralizedRate(ovenData.balance)"
+                :value="collatoralizedRate(ovenData)"
                 max="100"
               >
-                {{ collatoralizedRate(ovenData.balance) }}%
+                {{ collatoralizedRate(ovenData) }}%
               </progress>
             </div>
           </div>
@@ -402,7 +402,7 @@ export default {
         .dividedBy(Math.pow(10, 6))
         .multipliedBy(ovenBalance.dividedBy(Math.pow(10, 6)));
 
-      let valueHalf = currentValue.dividedBy(2);
+      let valueHalf = currentValue.dividedBy(this.$store.collateralOperand);
 
       let borrowedTokens = this.ovenData.outstandingTokens.dividedBy(
         Math.pow(10, 18)
@@ -410,23 +410,8 @@ export default {
 
       return valueHalf.minus(borrowedTokens).decimalPlaces(18);
     },
-    collatoralizedRate(ovenBalance) {
-      if (parseInt(ovenBalance) === 0) {
-        return 0;
-      }
-
-      let currentValue = this.$store.priceData.price
-        .dividedBy(Math.pow(10, 6))
-        .multipliedBy(ovenBalance.dividedBy(Math.pow(10, 6)))
-
-      let valueHalf = currentValue.dividedBy(2);
-
-      let rate = this.ovenData.outstandingTokens
-        .dividedBy(Math.pow(10, 18))
-        .dividedBy(valueHalf)
-        .times(100);
-
-      return rate.toFixed(2);
+    collatoralizedRate(oven) {
+      return this.collatoralizedRateForOven(oven)
     },
     async updateOvenData() {
       const keys = [

--- a/src/components/PegVisualizer.vue
+++ b/src/components/PegVisualizer.vue
@@ -105,10 +105,10 @@ export default {
       const harbingerPrice = this.$store.priceData.price.div(tezMantissa)
 
       const percentOff = new BigNumber(1).minus(harbingerPrice.dividedBy(quipuPrice))
-      const halfPercentOff = percentOff.dividedBy(2)
+      const halfPercentOff = percentOff.dividedBy(this.$store.collateralOperand)
       const kusdToRecv = tokenPool.times(halfPercentOff)
 
-      const onePercentOff = new BigNumber("0.01").dividedBy(2)
+      const onePercentOff = new BigNumber("0.01").dividedBy(this.$store.collateralOperand)
       const pegDepth = tokenPool.times(onePercentOff)
 
       const updatedTokenPoolAmt = tokenPool.minus(kusdToRecv)

--- a/src/components/PublicOven.vue
+++ b/src/components/PublicOven.vue
@@ -72,7 +72,7 @@
                   !oven.isLiquidated &&
                   $store.collateralRate
                     .dividedBy(Math.pow(10, 18))
-                    .dividedBy(2)
+                    .dividedBy(this.$store.collateralOperand)
                     .isLessThan(collatoralizedRateForOven(oven))
                 "
                 class="button is-danger is-small">
@@ -305,7 +305,7 @@ export default {
       let currentValue = this.$store.priceData.price
         .multipliedBy(ovenBalance)
         .dividedBy(Math.pow(10, 10));
-      let valueHalf = currentValue.dividedBy(2);
+      let valueHalf = currentValue.dividedBy(this.$store.collateralOperand);
 
       let borrowedTokens = this.oven.outstandingTokens.dividedBy(Math.pow(10, 18));
 
@@ -319,7 +319,7 @@ export default {
       let currentValue = this.$store.priceData.price
         .multipliedBy(ovenBalance)
         .dividedBy(Math.pow(10, 10));
-      let valueHalf = currentValue.dividedBy(2);
+      let valueHalf = currentValue.dividedBy(this.$store.collateralOperand);
 
       let rate = this.oven.outstandingTokens
         .dividedBy(valueHalf)
@@ -339,12 +339,12 @@ export default {
       return this.$store.collateralRate
         .plus(this.$store.privateLiquidationThreshold)
         .dividedBy(Math.pow(10, 18))
-        .dividedBy(2)
+        .dividedBy(this.$store.collateralOperand)
     },
     lpLiquidationThreshold(){
       return this.$store.collateralRate
         .dividedBy(Math.pow(10, 18))
-        .dividedBy(2)
+        .dividedBy(this.$store.collateralOperand)
     }
   },
   components: {

--- a/src/components/modal-subviews/Borrow.vue
+++ b/src/components/modal-subviews/Borrow.vue
@@ -46,7 +46,7 @@
       <p class="heading">
         <a
           v-if="borrowAmtNumber.isLessThanOrEqualTo(maxSafeAmt.times(1.01))"
-          @click="borrowAmount = maxSafeAmt"
+          @click="borrowAmount = maxSafeAmt.toFixed(2)"
           class="has-text-weight-bold"
           >Max Safe (80%)</a
         >
@@ -178,10 +178,10 @@ export default {
   computed: {
     maxSafeAmt() {
       return this.ovenDollarValue(this.ovenAddress)
-        .dividedBy(2)
-        .multipliedBy(0.8)
-        .minus(this.outstandingTokensFormatted(this.ovenAddress))
-        .decimalPlaces(18);
+      .dividedBy(this.$store.collateralOperand)
+      .multipliedBy(0.8)
+      .minus(this.outstandingTokensFormatted(this.ovenAddress))
+      .decimalPlaces(18);
     },
     shouldAllowBorrow() {
       if (!this.borrowAmount || this.borrowAmount <= 0) {
@@ -203,7 +203,7 @@ export default {
         borrowAmount = 0;
       }
 
-      const maxCollateral = this.ovenDollarValue(this.ovenAddress).dividedBy(2);
+      const maxCollateral = this.ovenDollarValue(this.ovenAddress).dividedBy(this.$store.collateralOperand);
 
       const borrowedTokens = this.outstandingTokensFormatted(this.ovenAddress);
 

--- a/src/components/modal-subviews/Deposit.vue
+++ b/src/components/modal-subviews/Deposit.vue
@@ -159,7 +159,7 @@ export default {
         depositAmount = 0
       }
 
-      const maxCollateral = this.ovenDollarValuePlusDeposit(this.ovenAddress, depositAmount).dividedBy(2)
+      const maxCollateral = this.ovenDollarValuePlusDeposit(this.ovenAddress, depositAmount).dividedBy(this.$store.collateralOperand)
 
       const borrowedTokens = this.outstandingTokensFormatted(this.ovenAddress)
 

--- a/src/components/modal-subviews/Repay.vue
+++ b/src/components/modal-subviews/Repay.vue
@@ -224,7 +224,7 @@ export default {
         repayAmount = 0;
       }
 
-      const maxCollateral = this.ovenDollarValue(this.ovenAddress).dividedBy(2);
+      const maxCollateral = this.ovenDollarValue(this.ovenAddress).dividedBy(this.$store.collateralOperand);
 
       const borrowedTokens = this.outstandingTokensFormatted(this.ovenAddress);
 

--- a/src/components/modal-subviews/Withdraw.vue
+++ b/src/components/modal-subviews/Withdraw.vue
@@ -162,7 +162,7 @@ export default {
       const ovenValue = this.ovenDollarValue(this.ovenAddress); // USD
 
       let ovenValueFormatted = ovenValue
-        .dividedBy(2)
+        .dividedBy(this.$store.collateralOperand)
         .minus(borrowedTokens)
         .dividedBy(this.currentPriceFormatted())
         .times(2)
@@ -198,7 +198,7 @@ export default {
       const maxCollateralDollars = this.ovenDollarValueMinusWithdraw(
         this.ovenAddress,
         withdrawAmount
-      ).dividedBy(2);
+      ).dividedBy(this.$store.collateralOperand);
 
       const borrowedTokens = this.outstandingTokensFormatted(this.ovenAddress);
 

--- a/src/store.js
+++ b/src/store.js
@@ -146,6 +146,7 @@ let state = Vue.observable({
     stabilityFee: null,
     privateLiquidationThreshold: null,
     collateralRate: null,
+    collateralOperand: null,
     ownedOvens: null,
     balanceData: null,
     wallet: null,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,31 @@
+import BigNumber from "bignumber.js"
+/*
+Credits goes to: https://github.com/Hover-Labs/kolibri-js/blob/master/src/oven-client.ts
+As the vast majority of helpers from here were either took, modified or inspired from kolibri-js module
+*/
+
+const MUTEZ_DIGITS = 6
+const SHARD_DIGITS = 18
+
+const MUTEZ_TO_SHARD = new BigNumber(Math.pow(10, SHARD_DIGITS - MUTEZ_DIGITS))
+
+const SHARD_PRECISION = new BigNumber(Math.pow(10, SHARD_DIGITS))
+
+export const customGetCollateralUtilization = (
+  price,
+  balance,
+  outstandingTokens
+) => {
+  const priceShard = price.multipliedBy(MUTEZ_TO_SHARD)
+  const collateralValue = balance
+    .multipliedBy(MUTEZ_TO_SHARD)
+    .multipliedBy(priceShard)
+    .dividedBy(SHARD_PRECISION)
+
+  return new BigNumber(
+    outstandingTokens
+      .times(Math.pow(10, SHARD_DIGITS))
+      .dividedBy(collateralValue)
+      .toFixed(0)
+  )
+}


### PR DESCRIPTION
Hello,

I give this a try as the UI and all buttons are currently broken at the moment due to the change from 200-20 (180 collateral ratio) to 155-5 (150 collateral ratio).

From my understanding it seems there were a lot of computation that was doing the dividedBy(2) which is comming from the 200 if I'm not mistaken.

I tried to update this to 150 in our case. I'll appreciate that people give this an overview as I am not sure I've covered the entire repo as there is various place where similar computation happens and it's not necesarily convenient to make sure I've addressed them all.

From visual testing I was able to see consistent data in percentages for both AllOven page and Oven page.

Also I'm not sure If I had to take the 155-5 or 155 from the computation but I can update that easily if I took the wrong one.

If anyone know how to do that better or cleaner, feel free to fork, or make a pr on top of the one I've done.