### PR TITLE
fix(rpc): replace dead ECAD Labs nodes with TzKT/SmartPy

### DIFF
--- a/src/components/Options.vue
+++ b/src/components/Options.vue
@@ -206,19 +206,12 @@ export default {
       }
     } else {
       nodes = {
-        ECADLabs: {
-          hangzhounet: 'https://hangzhounet.api.tez.ie',
-          granadanet: 'https://granadanet.api.tez.ie',
-          mainnet: 'https://mainnet.api.tez.ie',
+        TzKT: {
+          mainnet: 'https://rpc.tzkt.io/mainnet',
         },
         SmartPy: {
-          granadanet: 'https://granadanet.smartpy.io',
           mainnet: 'https://mainnet.smartpy.io',
         },
-        TZBeta: {
-          granadanet: 'https://rpctest.tzbeta.net',
-          mainnet: 'https://rpc.tzbeta.net',
-        }
       }
     }
 

--- a/src/components/Options.vue
+++ b/src/components/Options.vue
@@ -212,6 +212,12 @@ export default {
         SmartPy: {
           mainnet: 'https://mainnet.smartpy.io',
         },
+        'Tezos Commons': {
+          mainnet: 'https://mainnet.tcinfra.net',
+        },
+        'Tezos Foundation': {
+          mainnet: 'https://rpc.tzbeta.net',
+        },
       }
     }
 

--- a/src/store.js
+++ b/src/store.js
@@ -95,7 +95,7 @@ if ((
 
     dontIndexTestnets()
 } else {
-    NODE_URL = 'https://mainnet.api.tez.ie'
+    NODE_URL = 'https://rpc.tzkt.io/mainnet'
 
     NETWORK = Network.Mainnet
     NETWORK_CONTRACTS = CONTRACTS.MAIN
@@ -135,8 +135,39 @@ if (ovenNameMapping !== null) {
     ovenNames = {}
 }
 
+// ECAD Labs shut down, taking down api.tez.ie and ecadinfra.com. Drop any saved override
+// pointing at a known-dead host so existing users fall back to the working default instead
+// of staying stuck on a node that will never respond. Deterministic (no startup probing) so
+// a transient outage never erases a user's legitimate custom RPC.
+const DEAD_NODE_HOSTS = new Set([
+    'mainnet.api.tez.ie',
+    'hangzhounet.api.tez.ie',
+    'granadanet.api.tez.ie',
+    'mainnet.ecadinfra.com',
+    'ghostnet.ecadinfra.com',
+    'rpc.tzbeta.net',
+    'rpctest.tzbeta.net',
+    'rpczero.tzbeta.net',
+])
+
+const isDeadNodeOverride = (nodeURL) => {
+    if (!nodeURL) {
+        return false
+    }
+    try {
+        return DEAD_NODE_HOSTS.has(new URL(nodeURL).hostname)
+    } catch (e) {
+        return false
+    }
+}
+
 const nodeOverrideKey = `${NETWORK}-nodeOverride`
-NODE_URL = localStorage.getItem(nodeOverrideKey) ? localStorage.getItem(nodeOverrideKey) : NODE_URL
+const savedNodeURL = localStorage.getItem(nodeOverrideKey)
+const savedNodeIsDead = isDeadNodeOverride(savedNodeURL)
+if (savedNodeIsDead) {
+    localStorage.removeItem(nodeOverrideKey)
+}
+NODE_URL = savedNodeIsDead ? NODE_URL : (savedNodeURL || NODE_URL)
 
 let state = Vue.observable({
     currentBlockHeight: null,

--- a/src/store.js
+++ b/src/store.js
@@ -145,9 +145,6 @@ const DEAD_NODE_HOSTS = new Set([
     'granadanet.api.tez.ie',
     'mainnet.ecadinfra.com',
     'ghostnet.ecadinfra.com',
-    'rpc.tzbeta.net',
-    'rpctest.tzbeta.net',
-    'rpczero.tzbeta.net',
 ])
 
 const isDeadNodeOverride = (nodeURL) => {


### PR DESCRIPTION
ECAD Labs shut down, taking down api.tez.ie and ecadinfra.com. The default mainnet RPC node (https://mainnet.api.tez.ie) and the ECADLabs/TZBeta dropdown entries no longer respond.

- Default mainnet node -> https://rpc.tzkt.io/mainnet (verified 200 + CORS *)
- RPC dropdown: keep TzKT (default) + SmartPy, drop dead ECADLabs/TZBeta
- Clear saved localStorage node overrides pointing at known-dead hosts so existing users fall back to a working node instead of staying stuck